### PR TITLE
CSV Header Parsing

### DIFF
--- a/src/frontend/CommunicationProtocol/Receivers/CSVReader.cs
+++ b/src/frontend/CommunicationProtocol/Receivers/CSVReader.cs
@@ -5,6 +5,8 @@ namespace CommunicationProtocol.Receivers
 {
     public abstract class CSVReader<T> : List<T>
     {
+        protected Dictionary<string, int> headerMap = new Dictionary<string, int>();
+
         // Constructor to load data when instantiated
         public CSVReader(string path)
         {
@@ -23,8 +25,14 @@ namespace CommunicationProtocol.Receivers
             // Read the CSV file line by line and parse each row using the concrete implementation of ParseRow
             using (var reader = new StreamReader(path))
             {
-                // Skip the header row
-                reader.ReadLine();
+
+                // Read the header row and store the index of each column
+                var header = reader.ReadLine();
+                var headerValues = header.Split(',');
+                for (int i = 0; i < headerValues.Length; i++)
+                {
+                    headerMap[headerValues[i]] = i;
+                }
 
                 while (!reader.EndOfStream)
                 {

--- a/src/frontend/CommunicationProtocol/Receivers/InputParameters.cs
+++ b/src/frontend/CommunicationProtocol/Receivers/InputParameters.cs
@@ -4,13 +4,11 @@ namespace CommunicationProtocol.Receivers
 {
     public class InputParameters : CSVReader<Parameter>
     {
-        public InputParameters(string path) : base(path)
-        {
-        }
+        public InputParameters(string path) : base(path) {}
 
         protected override Parameter ParseRow(string[] values)
         {
-            return new Parameter(values[0], values[1]);
+            return new Parameter(values[headerMap["Name"]], values[headerMap["Value"]]);
         }
 
         public string GetValue(string name)

--- a/src/frontend/CommunicationProtocol/Receivers/SimulationResult.cs
+++ b/src/frontend/CommunicationProtocol/Receivers/SimulationResult.cs
@@ -60,12 +60,12 @@ namespace CommunicationProtocol.Receivers
 
         protected override DataPoint ParseRow(string[] values)
         {
-            float time = float.Parse(values[0]);
-            float engineAngularVelocity = float.Parse(values[1]);
-            float engineAngularPosition = float.Parse(values[2]);
-            float carVelocity = float.Parse(values[3]);
-            float carPosition = float.Parse(values[4]);
-            float shiftDistance = float.Parse(values[6]);
+            float time = float.Parse(values[headerMap["time"]]);
+            float engineAngularVelocity = float.Parse(values[headerMap["engine_angular_velocity"]]);
+            float engineAngularPosition = float.Parse(values[headerMap["engine_angular_position"]]);
+            float carVelocity = float.Parse(values[headerMap["car_velocity"]]);
+            float carPosition = float.Parse(values[headerMap["car_position"]]);
+            float shiftDistance = float.Parse(values[headerMap["shift_distance"]]);
 
             return new DataPoint(time, engineAngularVelocity, engineAngularPosition, carVelocity, carPosition, shiftDistance);
         }

--- a/src/frontend/CommunicationProtocolUnitTesting/SimulationResultTest.cs
+++ b/src/frontend/CommunicationProtocolUnitTesting/SimulationResultTest.cs
@@ -13,7 +13,7 @@ namespace CommunicationProtocolUnitTesting
         public void SetUp()
         {
             // Write test data to the file
-            File.WriteAllText(CSVPath, "time,engine_angular_velocity,engine_angular_position,car_velocity,car_position,shift_distance\n" +
+            File.WriteAllText(CSVPath, "time,engine_angular_velocity,engine_angular_position,car_velocity,car_position,shift_velocity,shift_distance\n" +
                                        "0,10,0.1,20,30,0,0.005\n" +
                                        "1,15,0.2,25,35,0,0.010\n");
         }


### PR DESCRIPTION
**Description**
Changes the parsing of the columns to use the headers as index references instead of using direct indexing

**Changes**
List the main changes made in this PR:
- [x] Updated indexing of csv readers to use headers