### PR TITLE
Speeding up simulation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -161,6 +161,8 @@ solution_phase1 = solve_ivp(
         car_velocity_constraint_event,
         shift_constraint_event,
     ],
+    atol=1e-6,
+    rtol=1e-4,
 )
 
 if solution_phase1.t_events[0].size > 0:

--- a/src/simulations/cvt_shift.py
+++ b/src/simulations/cvt_shift.py
@@ -21,7 +21,7 @@ class CvtShift:
         self.secondary_simulator = secondary_simulator
         self.primary_belt = primary_belt
         self.secondary_belt = secondary_belt
-        self.cvt_moving_mass = 10  # TODO: Use constants
+        self.cvt_moving_mass = 0.5  # TODO: Use constants
 
     def get_pulley_forces(self, state: SystemState):
         # Compute CVT ratio and engine velocity


### PR DESCRIPTION
**Description**
Focused on splitting the simulation into two portions to avoid critical regions in calculations. Now completes in seconds.

**Changes**
List the main changes made in this PR:
- [x] Split simulation into 2 parts 
- [x] Added constraint to detect split

