### PR TITLE
ReplayController and Tooltip

### DIFF
--- a/cvtModel/src/cvt_simulator/simulation_runner.py
+++ b/cvtModel/src/cvt_simulator/simulation_runner.py
@@ -88,10 +88,12 @@ class SimulationRunner:
 
                 # Phase 1 output is already truncated by the event; just append phase 2
                 combined_t = np.concatenate([solution_phase1.t, solution_phase2.t])
-                combined_y = np.hstack([
-                    solution_phase1.y,
-                    solution_phase2.y,
-                ])
+                combined_y = np.hstack(
+                    [
+                        solution_phase1.y,
+                        solution_phase2.y,
+                    ]
+                )
             else:
                 # No remaining time points to evaluate in phase 2
                 combined_t = solution_phase1.t

--- a/cvtModel/src/cvt_simulator/simulation_runner.py
+++ b/cvtModel/src/cvt_simulator/simulation_runner.py
@@ -51,7 +51,8 @@ class SimulationRunner:
     def run_simulation(self) -> SimulationResult:
         """Run the simulation and return results."""
         cvt_system_ode = self._get_ode_function()
-        time_eval_phase1 = np.linspace(0, self.TOTAL_SIM_TIME, 10000)
+        # Use a single global time grid for the entire simulation
+        time_eval = np.linspace(0, self.TOTAL_SIM_TIME, 10000)
         events = [
             get_shift_steady_event(self.cvt_shift_model),
             car_velocity_constraint_event,
@@ -62,7 +63,7 @@ class SimulationRunner:
             cvt_system_ode,
             0,
             self.INITIAL_STATE.to_array(),
-            time_eval_phase1,
+            time_eval,
             events,
         )
 
@@ -71,26 +72,30 @@ class SimulationRunner:
             event_time = solution_phase1.t_events[0][0]
             event_state = solution_phase1.y_events[0][0]
 
-            # Define a new t_eval for phase 2 (you can adjust the number of points as needed)
-            time_eval_phase2 = np.linspace(event_time, self.TOTAL_SIM_TIME, 1000)
-
             cvt_system_full_shift_ode = self._get_full_shift_ode_function()
 
-            solution_phase2 = self._solve(
-                cvt_system_full_shift_ode,
-                event_time,
-                event_state,
-                time_eval_phase2,
-                [car_velocity_constraint_event],
-            )
+            # Use the remaining portion of the original time grid for phase 2
+            time_eval_phase2 = time_eval[time_eval > event_time]
 
-            phase1_indices = solution_phase1.t <= event_time
-            combined_t = np.concatenate(
-                [solution_phase1.t[phase1_indices], solution_phase2.t[1:]]
-            )
-            combined_y = np.hstack(
-                [solution_phase1.y[:, phase1_indices], solution_phase2.y[:, 1:]]
-            )
+            if time_eval_phase2.size > 0:
+                solution_phase2 = self._solve(
+                    cvt_system_full_shift_ode,
+                    event_time,
+                    event_state,
+                    time_eval_phase2,
+                    [car_velocity_constraint_event],
+                )
+
+                # Phase 1 output is already truncated by the event; just append phase 2
+                combined_t = np.concatenate([solution_phase1.t, solution_phase2.t])
+                combined_y = np.hstack([
+                    solution_phase1.y,
+                    solution_phase2.y,
+                ])
+            else:
+                # No remaining time points to evaluate in phase 2
+                combined_t = solution_phase1.t
+                combined_y = solution_phase1.y
         else:
             # Otherwise, use the phase 1 solution entirely.
             combined_t = solution_phase1.t

--- a/frontend/src/components/graph2D/chartOptions.ts
+++ b/frontend/src/components/graph2D/chartOptions.ts
@@ -104,6 +104,13 @@ const CHART_DEFAULTS = {
 } as const;
 
 /**
+ * Stable value formatter function to prevent unnecessary re-renders for tooltip
+ */
+const stableValueFormatter = (value: unknown): string => {
+  return typeof value === 'number' ? value.toFixed(2) : String(value);
+};
+
+/**
  * Deep merge function for objects
  */
 function deepMerge<T extends Record<string, unknown>>(target: T, source: Partial<T>): T {
@@ -252,6 +259,7 @@ export function generateEChartsOptions(
       backgroundColor: COLORS.TOOLTIP_BG,
       borderColor: COLORS.GRID,
       textStyle: { color: COLORS.TEXT },
+      valueFormatter: stableValueFormatter,
     },
     
     // TODO: Only enable if playback paused
@@ -399,5 +407,6 @@ export function createActiveIndexLabel(
       text,
       fill: COLORS.TEXT,
     },
+    silent: true,
   }];
 }

--- a/frontend/src/components/playbar/Playbar.tsx
+++ b/frontend/src/components/playbar/Playbar.tsx
@@ -14,6 +14,19 @@ interface PlaybarProps {
 // Be aware that this places the times evenly along the slider, not according to their actual values.
 // This is because the slider only supports linear scales. If we want a non-linear scale, we would need to implement a custom slider.
 export const Playbar = ({ replayController, times }: PlaybarProps) => {
+    // Format seconds to m:ss:ss (minutes:seconds:hundredths). Handles undefined and negatives gracefully.
+    const formatTime = (sec?: number) => {
+        if (sec == null || !Number.isFinite(sec)) return '-:--:--';
+        const clamped = Math.max(0, sec);
+        const totalSec = Math.floor(clamped);
+        const m = Math.floor(totalSec / 60);
+        const s = totalSec % 60;
+        const fractional = clamped - totalSec;
+        // Hundredths of a second (00-99), avoid rounding to 100
+        const hs = Math.floor(Math.min(0.9999, Math.max(0, fractional)) * 100);
+        return `${m}:${s.toString().padStart(2, '0')}:${hs.toString().padStart(2, '0')}`;
+    };
+
     const [isPlaying, setIsPlaying] = useState(false);
     const [currentIndex, setCurrentIndex] = useState(0);
     const [speed, setSpeed] = useState(1);
@@ -84,7 +97,7 @@ export const Playbar = ({ replayController, times }: PlaybarProps) => {
                 sx={{ flex: 1, mx: 2 }}
             />
             <span className={styles.indexLabel}>
-                {currentIndex + 1} / {times.length} ({times[currentIndex] ?? '-'})
+                {formatTime(times[currentIndex])} / {formatTime(times[times.length - 1])}
             </span>
             <label className={styles.speedLabel}>
                 Speed:

--- a/frontend/src/pages/playback/Playback.tsx
+++ b/frontend/src/pages/playback/Playback.tsx
@@ -34,13 +34,13 @@ export const Playback = () => {
                 text={'Home'}
                 icon={Home}
                 className={styles.navigateButton}
-                onClick={() => navigate('/')}
+                onClick={() => {replayController.pause(); navigate('/')}}
             />
             <Button
                 text={'Edit'}
                 icon={Edit}
                 className={styles.navigateButton}
-                onClick={() => navigate('/input')}
+                onClick={() => {replayController.pause(); navigate('/input')}}
             />
             </div>
             <div className={styles.displayGrid}>

--- a/frontend/src/utils/ReplayController.ts
+++ b/frontend/src/utils/ReplayController.ts
@@ -84,7 +84,7 @@ export class ReplayController {
 
   pause() {
     this.isPlaying = false;
-     if (this.rafId != null) {
+    if (this.rafId != null) {
       cancelAnimationFrame(this.rafId);
       this.rafId = null;
     }

--- a/frontend/src/utils/ReplayController.ts
+++ b/frontend/src/utils/ReplayController.ts
@@ -32,9 +32,6 @@ export class ReplayController {
   private rafId: number | null = null;
   private loopBound = (now: number) => this.loop(now);
 
-  // limit CPU per frame so paint can happen
-  private frameBudgetMs = 8; // tweak or set to Infinity to disable
-
   constructor(
     data: ReplayData,
   ) {
@@ -131,8 +128,7 @@ export class ReplayController {
 
    /** Advance indices up to the given elapsed time.
    * Returns the latest DataPoint processed in this frame (or null). */
-  private stepUntil(elapsedSeconds: number, budgetMs: number): DataPoint | null {
-    const start = performance.now();
+  private stepUntil(elapsedSeconds: number): DataPoint | null {
     let lastPoint: DataPoint | null = null;
 
     while (
@@ -142,9 +138,6 @@ export class ReplayController {
       lastPoint = this.data[this.currentIndex];
       this.lastTimestamp = lastPoint.time;
       this.currentIndex++;
-
-      // optional frame budget to leave time for paint/React
-      if (performance.now() - start >= budgetMs) break;
     }
 
     return lastPoint;
@@ -159,7 +152,7 @@ export class ReplayController {
     if (!this.isPlaying) return;
 
     const elapsedSec = ((now - this.startTime) / 1000) * this.speed;
-    const latest = this.stepUntil(elapsedSec, this.frameBudgetMs);
+    const latest = this.stepUntil(elapsedSec);
 
     if (latest) {
       this.emit({

--- a/frontend/src/utils/ReplayController.ts
+++ b/frontend/src/utils/ReplayController.ts
@@ -28,6 +28,13 @@ export class ReplayController {
   private speed = 1;
   private listeners: ((event: ReplayEvent) => void)[] = [];
 
+  // rAF management
+  private rafId: number | null = null;
+  private loopBound = (now: number) => this.loop(now);
+
+  // limit CPU per frame so paint can happen
+  private frameBudgetMs = 8; // tweak or set to Infinity to disable
+
   constructor(
     data: ReplayData,
   ) {
@@ -73,11 +80,17 @@ export class ReplayController {
     this.emit({ type: ReplayEventType.StateChanged, state: StateType.Playing });
     this.isPlaying = true;
 
-    this.loop();
+    // ensure only one rAF loop
+    if (this.rafId != null) cancelAnimationFrame(this.rafId);
+    this.rafId = requestAnimationFrame(this.loopBound);
   }
 
   pause() {
     this.isPlaying = false;
+     if (this.rafId != null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
     this.emit({ type: ReplayEventType.StateChanged, state: StateType.Paused });
   }
 
@@ -91,6 +104,12 @@ export class ReplayController {
       // TODO: Remove debugging statement
       console.warn('Speed must be positive. Ignoring invalid value:', newSpeed);
       return;
+    }
+    // keep timeline continuous when changing speed during playback
+    if (this.isPlaying) {
+      const now = performance.now();
+      const elapsedSec = ((now - this.startTime) / 1000) * this.speed;
+      this.startTime = now - (elapsedSec * 1000) / newSpeed;
     }
     this.speed = newSpeed;
   }
@@ -110,26 +129,44 @@ export class ReplayController {
     }
   }
 
-  private loop() {
-    if (!this.isPlaying) return;
-
-    const now = performance.now();
-    const elapsed = ((now - this.startTime) / 1000) * this.speed; // Convert ms to seconds
+   /** Advance indices up to the given elapsed time.
+   * Returns the latest DataPoint processed in this frame (or null). */
+  private stepUntil(elapsedSeconds: number, budgetMs: number): DataPoint | null {
+    const start = performance.now();
+    let lastPoint: DataPoint | null = null;
 
     while (
       this.currentIndex < this.data.length &&
-      this.data[this.currentIndex].time <= elapsed
+      this.data[this.currentIndex].time <= elapsedSeconds
     ) {
-      const dataPoint = this.data[this.currentIndex];
+      lastPoint = this.data[this.currentIndex];
+      this.lastTimestamp = lastPoint.time;
+      this.currentIndex++;
 
+      // optional frame budget to leave time for paint/React
+      if (performance.now() - start >= budgetMs) break;
+    }
+
+    return lastPoint;
+  }
+
+  /** Single rAF callback that:
+   *  - computes elapsed,
+   *  - advances simulation (possibly multiple data points),
+   *  - emits at most once with the latest point,
+   *  - schedules the next frame. */
+  private loop(now: number) {
+    if (!this.isPlaying) return;
+
+    const elapsedSec = ((now - this.startTime) / 1000) * this.speed;
+    const latest = this.stepUntil(elapsedSec, this.frameBudgetMs);
+
+    if (latest) {
       this.emit({
         type: ReplayEventType.Progress,
         currentIndex: this.currentIndex,
-        data: dataPoint,
+        data: latest, // only the newest point this frame
       });
-
-      this.lastTimestamp = dataPoint.time;
-      this.currentIndex++;
     }
 
     if (this.currentIndex >= this.data.length) {
@@ -138,7 +175,6 @@ export class ReplayController {
       return;
     }
 
-    // Continue the loop
-    requestAnimationFrame(this.loop.bind(this));
+    this.rafId = requestAnimationFrame(this.loopBound);
   }
 }


### PR DESCRIPTION
**Description**
These are related issues so Im handling them in the same spot. Firstly are the changes to replayController (rAF = requestAnimationFrame)

rAF will submit say `n` animation requests
on each new frame, browser will render each of these in succession and then show the final result
Since we are updating only one point, no need to emit or process more than 1 animation per frame
This drops it from before (it was at 20 emits per frame down to 1 now)


**Changes**
List the main changes made in this PR:
- [x] Updated sim to output evenly spaced times
- [x] Formatted time on playbar to avoid jumping around, revealed new issue with MUI playbar
- [x] replayController above
- [x] Tooltip formatted
