### PR TITLE
324 feature display units on graph

### DIFF
--- a/frontend/src/components/graph2D/chartOptions.ts
+++ b/frontend/src/components/graph2D/chartOptions.ts
@@ -1,4 +1,8 @@
-import type { EChartsOption, MarkLineComponentOption } from 'echarts';
+import type { 
+  EChartsOption, 
+  MarkLineComponentOption, 
+  DefaultLabelFormatterCallbackParams 
+} from 'echarts';
 import { inferAxisType } from './validation';
 
 /**
@@ -111,6 +115,65 @@ const stableValueFormatter = (value: unknown): string => {
 };
 
 /**
+ * Cache for memoized tooltip formatters to prevent unnecessary re-renders
+ */
+const tooltipFormatterCache = new Map<string, (params: DefaultLabelFormatterCallbackParams | DefaultLabelFormatterCallbackParams[]) => string>();
+
+/**
+ * Creates a tooltip formatter that includes units.
+ * Returns either a string template or a stable function reference.
+ */
+function createTooltipFormatter(config: ChartConfig) {
+  // For simple cases, we could use ECharts string templates:
+  // return `${config.xAxis.name}: {c0}<br/>${config.yAxis.name}: {c1}`;
+  
+  // But for unit support and formatting, we need the function approach with caching
+  const cacheKey = JSON.stringify({
+    xAxisName: config.xAxis.name,
+    yAxisName: config.yAxis.name,
+    xAxisUnit: config.xAxis.unit,
+    yAxisUnit: config.yAxis.unit,
+  });
+  
+  // Return cached formatter if it exists
+  if (tooltipFormatterCache.has(cacheKey)) {
+    return tooltipFormatterCache.get(cacheKey)!;
+  }
+  
+  // Create new formatter
+  const formatter = (params: DefaultLabelFormatterCallbackParams | DefaultLabelFormatterCallbackParams[]) => {
+    // ECharts passes either a single param object or an array of param objects
+    // For 'axis' trigger (which we use), it's always an array
+    const paramArray = Array.isArray(params) ? params : [params];
+    
+    if (paramArray.length > 0) {
+      const param = paramArray[0];
+      
+      // For line charts with dataset, data comes in param.value as [x, y]
+      // or for some configurations it might be in param.data
+      const dataValues = Array.isArray(param.value) ? param.value : param.data;
+      
+      if (Array.isArray(dataValues) && dataValues.length >= 2) {
+        const [xValue, yValue] = dataValues;
+        
+        const xUnit = config.xAxis.unit ? ` ${config.xAxis.unit}` : '';
+        const yUnit = config.yAxis.unit ? ` ${config.yAxis.unit}` : '';
+        
+        return `
+          ${config.xAxis.name}: ${stableValueFormatter(xValue)}${xUnit}<br/>
+          ${config.yAxis.name}: ${stableValueFormatter(yValue)}${yUnit}
+        `;
+      }
+    }
+    return '';
+  };
+  
+  // Cache and return the formatter
+  tooltipFormatterCache.set(cacheKey, formatter);
+  return formatter;
+}
+
+/**
  * Deep merge function for objects
  */
 function deepMerge<T extends Record<string, unknown>>(target: T, source: Partial<T>): T {
@@ -207,7 +270,7 @@ export function generateEChartsOptions(
   // Create axis options separately to avoid type inference issues
   const xAxisOption = {
     type: config.xAxis.type,
-    name: config.xAxis.name,
+    name: config.xAxis.unit ? `${config.xAxis.name} (${config.xAxis.unit})` : config.xAxis.name,
     nameLocation: 'middle' as const,
     nameGap: LAYOUT.X_AXIS_NAME_GAP,
     nameTextStyle: { color: COLORS.TEXT },
@@ -223,7 +286,7 @@ export function generateEChartsOptions(
   
   const yAxisOption = {
     type: config.yAxis.type,
-    name: config.yAxis.name,
+    name: config.yAxis.unit ? `${config.yAxis.name} (${config.yAxis.unit})` : config.yAxis.name,
     nameLocation: 'middle' as const,
     nameGap: LAYOUT.Y_AXIS_NAME_GAP,
     nameTextStyle: { color: COLORS.TEXT },
@@ -259,7 +322,7 @@ export function generateEChartsOptions(
       backgroundColor: COLORS.TOOLTIP_BG,
       borderColor: COLORS.GRID,
       textStyle: { color: COLORS.TEXT },
-      valueFormatter: stableValueFormatter,
+      formatter: createTooltipFormatter(config),
     },
     
     // TODO: Only enable if playback paused
@@ -389,14 +452,17 @@ export function createActiveIndexLabel(
   if (activeIndex == null || activeIndex < 0 || activeIndex >= xData.length) return [];
 
   const [x, y] = [xData[activeIndex], yData[activeIndex]];
+  
+  const xUnit = config.xAxis.unit ? ` ${config.xAxis.unit}` : '';
+  const yUnit = config.yAxis.unit ? ` ${config.yAxis.unit}` : '';
 
   let text = '';
   if (config.showXLine && config.showYLine) {
-    text = `(${config.xAxis.name}: ${x.toFixed(2)}, ${config.yAxis.name}: ${y.toFixed(2)})`;
+    text = `(${config.xAxis.name}: ${x.toFixed(2)}${xUnit}, ${config.yAxis.name}: ${y.toFixed(2)}${yUnit})`;
   } else if (config.showXLine) {
-    text = `${config.yAxis.name}: ${y.toFixed(2)}`;
+    text = `${config.yAxis.name}: ${y.toFixed(2)}${yUnit}`;
   } else if (config.showYLine) {
-    text = `${config.xAxis.name}: ${x.toFixed(2)}`;
+    text = `${config.xAxis.name}: ${x.toFixed(2)}${xUnit}`;
   }
 
   return [{

--- a/frontend/src/pages/input/Input.tsx
+++ b/frontend/src/pages/input/Input.tsx
@@ -62,8 +62,7 @@ export const Input = () => {
 
             const apiBody = mapParametersToApiBody(parsedValues);
             const result = await runSimulation(apiBody);
-
-            const unitConversion = convertSimulationData(result, UNIT_PRESETS.IMPERIAL);
+            const unitConversion = convertSimulationData(result, UNIT_PRESETS.BAJA);
 
             navigate('/playback', { 
                 state: { simulationResult: unitConversion }

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -34,9 +34,9 @@ export const accessorToUnit = new Map<AccessorStrategy, BaseUnitType>([
 // Helper function to get unit label for an accessor
 function getAxisUnit(accessor: AccessorStrategy): string {
     const unitType = accessorToUnit.get(accessor);
-    if (!unitType) return 'No unit found';
+    if (!unitType) return 'No unit associated with accessor!';
     
-    // Get SI unit as default
+    // Get BAJA unit as default
     const unit = getTargetUnit(unitType, UNIT_PRESETS.BAJA);
     return unit || '';
 }

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -1,5 +1,7 @@
 import type { Graph2DProps } from "@components/graph2D/graph2D";
 import type { RunResponse } from "@utils/api";
+import type { BaseUnitType } from "@utils/unitConversion";
+import { UNIT_PRESETS, getTargetUnit } from "@utils/unitConversion";
 
 type DataPoint = RunResponse['data'][number]; // TODO: Move to somewhere else (maybe replay controller file)
 
@@ -18,14 +20,35 @@ const cvtRatioAccessor: AccessorStrategy = (point) => point.cvt_state.cvt_ratio;
 const engineRpmAccessor: AccessorStrategy = (point) => point.car_state.engine_forces.angular_velocity;
 const engineTorqueAccessor: AccessorStrategy = (point) => point.car_state.engine_forces.torque;
 
+// Mapping from accessor to unit type
+export const accessorToUnit = new Map<AccessorStrategy, BaseUnitType>([
+    [timeAccessor, 'time'],
+    [positionAccessor, 'distance'],
+    [velocityAccessor, 'velocity'],
+    [accelerationAccessor, 'acceleration'],
+    [cvtRatioAccessor, 'dimensionless'],
+    [engineRpmAccessor, 'angular_velocity'],
+    [engineTorqueAccessor, 'torque'],
+]);
+
+// Helper function to get unit label for an accessor
+function getAxisUnit(accessor: AccessorStrategy): string {
+    const unitType = accessorToUnit.get(accessor);
+    if (!unitType) return 'No unit found';
+    
+    // Get SI unit as default
+    const unit = getTargetUnit(unitType, UNIT_PRESETS.BAJA);
+    return unit || '';
+}
+
 export const graphConfigs: GraphConfig[] = [
     {
         xAccessor: timeAccessor,
         yAccessor: positionAccessor,
         config: {
             title: "Position vs Time",
-            xAxis: { name: "Time", type: "value", unit: "s" },
-            yAxis: { name: "Position", type: "value", unit: "m" },
+            xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
+            yAxis: { name: "Position", type: "value", unit: getAxisUnit(positionAccessor) },
             height: 400,
             showXLine: true,
             showYLine: false
@@ -36,8 +59,8 @@ export const graphConfigs: GraphConfig[] = [
         yAccessor: velocityAccessor,
         config: {
           title: "Velocity vs Time",
-          xAxis: { name: "Time", type: "value", unit: "s" },
-          yAxis: { name: "Velocity", type: "value", unit: "m/s" },
+          xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
+          yAxis: { name: "Velocity", type: "value", unit: getAxisUnit(velocityAccessor) },
           height: 400,
           showXLine: true,
           showYLine: true
@@ -48,8 +71,8 @@ export const graphConfigs: GraphConfig[] = [
         yAccessor: accelerationAccessor,
         config: {
             title: "Acceleration vs Time",
-            xAxis: { name: "Time", type: "value", unit: "s" },
-            yAxis: { name: "Acceleration", type: "value", unit: "m/s²" },
+            xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
+            yAxis: { name: "Acceleration", type: "value", unit: getAxisUnit(accelerationAccessor) },
             height: 400,
             showXLine: true,
             showYLine: false
@@ -60,8 +83,8 @@ export const graphConfigs: GraphConfig[] = [
         yAccessor: cvtRatioAccessor,
         config: {
             title: "CVT Ratio vs Time",
-            xAxis: { name: "Time", type: "value", unit: "s" },
-            yAxis: { name: "CVT Ratio", type: "value", unit: "ratio" },
+            xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
+            yAxis: { name: "CVT Ratio", type: "value", unit: getAxisUnit(cvtRatioAccessor) },
             height: 400,
             showXLine: true,
             showYLine: false
@@ -72,8 +95,8 @@ export const graphConfigs: GraphConfig[] = [
         yAccessor: engineRpmAccessor,
         config: {
             title: "Shift Curve (Engine RPM vs Vehicle Speed)",
-            xAxis: { name: "Vehicle Speed", type: "value", unit: "m/s" },
-            yAxis: { name: "Engine RPM", type: "value", unit: "rad/s" },
+            xAxis: { name: "Vehicle Speed", type: "value", unit: getAxisUnit(velocityAccessor) },
+            yAxis: { name: "Engine RPM", type: "value", unit: getAxisUnit(engineRpmAccessor) },
             height: 400,
             showXLine: true,
             showYLine: false
@@ -84,8 +107,8 @@ export const graphConfigs: GraphConfig[] = [
         yAccessor: engineTorqueAccessor,
         config: {
             title: "Engine Torque vs Time",
-            xAxis: { name: "Time", type: "value", unit: "s" },
-            yAxis: { name: "Engine Torque", type: "value", unit: "Nm" },
+            xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
+            yAxis: { name: "Engine Torque", type: "value", unit: getAxisUnit(engineTorqueAccessor) },
             height: 400,
             showXLine: true,
             showYLine: false

--- a/frontend/src/utils/unitConversion.ts
+++ b/frontend/src/utils/unitConversion.ts
@@ -14,7 +14,8 @@ export type BaseUnitType =
   | 'distance'           // m
   | 'acceleration'       // m/s²
   | 'angle'              // rad
-  | 'time';              // s
+  | 'time'               // s
+  | 'dimensionless';     // unitless ratios
 
 // Available unit options for each base type
 export type UnitOptions = {
@@ -28,6 +29,7 @@ export type UnitOptions = {
   acceleration: 'm/s²' | 'ft/s²' | 'g';
   angle: 'rad' | 'deg';
   time: 's' | 'min' | 'hr';
+  dimensionless: 'ratio' | '%';
 };
 
 // Core unit configuration - affects all values of that type
@@ -93,6 +95,10 @@ const CONVERSION_FACTORS: { [K in BaseUnitType]: Record<UnitOptions[K], number> 
     'min': 1 / 60,
     'hr': 1 / 3600,
   },
+  dimensionless: {
+    'ratio': 1,
+    '%': 100,
+  },
 } as const;
 
 // Default configuration (all SI units)
@@ -111,6 +117,7 @@ export const UNIT_PRESETS = {
     acceleration: 'm/s²',
     angle: 'rad',
     time: 's',
+    dimensionless: 'ratio',
   } as UnitConfiguration,
   
   IMPERIAL: {
@@ -123,6 +130,7 @@ export const UNIT_PRESETS = {
     distance: 'ft',
     acceleration: 'ft/s²',
     angle: 'deg',
+    dimensionless: '%',
   } as UnitConfiguration,
   
   BAJA: {
@@ -136,7 +144,7 @@ export const UNIT_PRESETS = {
 };
 
 // Helper function to get the target unit for a specific type
-function getTargetUnit<T extends BaseUnitType>(
+export function getTargetUnit<T extends BaseUnitType>(
   baseType: T,
   config: UnitConfiguration
 ): UnitOptions[T] {

--- a/frontend/src/utils/unitConversion.ts
+++ b/frontend/src/utils/unitConversion.ts
@@ -29,7 +29,8 @@ export type UnitOptions = {
   acceleration: 'm/s²' | 'ft/s²' | 'g';
   angle: 'rad' | 'deg';
   time: 's' | 'min' | 'hr';
-  dimensionless: 'ratio' | '%';
+  // Dimensionless set to empty for a ratio
+  dimensionless: '' | '%'; 
 };
 
 // Core unit configuration - affects all values of that type
@@ -96,7 +97,7 @@ const CONVERSION_FACTORS: { [K in BaseUnitType]: Record<UnitOptions[K], number> 
     'hr': 1 / 3600,
   },
   dimensionless: {
-    'ratio': 1,
+    '': 1,
     '%': 100,
   },
 } as const;
@@ -117,7 +118,7 @@ export const UNIT_PRESETS = {
     acceleration: 'm/s²',
     angle: 'rad',
     time: 's',
-    dimensionless: 'ratio',
+    dimensionless: '',
   } as UnitConfiguration,
   
   IMPERIAL: {


### PR DESCRIPTION
**Description**
Added flow from selected unit type to chartConfig / axisConfig, then displayed on tooltip and axes

**Changes**
List the main changes made in this PR:
- [x] Weird tooltip cache to avoid rerendering each time, without it its awful
- [x] Map from accessor to unit to avoid making changes when API type changes
- [x] Added dimensionless and used Baja as default

**Additional Notes**
https://github.com/gr812b/CVT-Simulator/issues/322 Should add central context for units and use this throughout.