### PR TITLE
Align Mark Lines and Point

### DIFF
--- a/frontend/src/components/graph2D/chartOptions.ts
+++ b/frontend/src/components/graph2D/chartOptions.ts
@@ -436,6 +436,7 @@ export function createMarkLines(
     lineStyle: { type: 'dashed', color: COLORS.TEXT },
     label: { show: false },
     symbol: 'none',
+    precision: 10,
     data,
   };
 }


### PR DESCRIPTION
**Description**
Fix issue where mark lines were rounding to 2 decimals and not aligning with point or data

**Changes**
List the main changes made in this PR:
- [x] Added precision to mark lines

**Screenshots (if applicable)**
<img width="945" height="313" alt="image" src="https://github.com/user-attachments/assets/0dfacede-f465-4c38-9553-17e0582926f7" />