### PR TITLE
382 feature update shown graphs

### DIFF
--- a/cvtModel/src/cvt_simulator/models/car_model.py
+++ b/cvtModel/src/cvt_simulator/models/car_model.py
@@ -34,6 +34,8 @@ class CarModel:
         )
 
         return CarForceBreakdown(
+            coupling_torque_at_wheel=coupling_torque * engine_to_wheel_ratio,
+            load_torque_at_wheel=load_torque,
             external_forces=self.load_model.get_breakdown(state.car_velocity),
             acceleration=accel,
         )

--- a/cvtModel/src/cvt_simulator/models/dataTypes.py
+++ b/cvtModel/src/cvt_simulator/models/dataTypes.py
@@ -115,6 +115,8 @@ class ExternalLoadForceBreakdown:
 ## Car
 @dataclass
 class CarForceBreakdown:
+    coupling_torque_at_wheel: float
+    load_torque_at_wheel: float
     external_forces: ExternalLoadForceBreakdown
     acceleration: float
 
@@ -123,6 +125,7 @@ class CarForceBreakdown:
 @dataclass
 class EngineForceBreakdown:
     torque: float
+    coupling_torque_at_engine: float
     power: float
     angular_velocity: float
     angular_acceleration: float

--- a/cvtModel/src/cvt_simulator/models/engine_accel_model.py
+++ b/cvtModel/src/cvt_simulator/models/engine_accel_model.py
@@ -22,6 +22,7 @@ class EngineAccelModel:
 
         return EngineForceBreakdown(
             torque=torque,
+            coupling_torque_at_engine=coupling_torque,
             power=power,
             angular_velocity=angular_velocity,
             angular_acceleration=angular_accel,

--- a/frontend/src/components/graph2D/chartOptions.ts
+++ b/frontend/src/components/graph2D/chartOptions.ts
@@ -145,6 +145,7 @@ function createTooltipFormatter(config: ChartConfig) {
     yAxisName: config.yAxis.name,
     xAxisUnit: config.xAxis.unit,
     yAxisUnit: config.yAxis.unit,
+    seriesNames: config.seriesNames,
   });
   
   // Return cached formatter if it exists

--- a/frontend/src/components/graph2D/chartOptions.ts
+++ b/frontend/src/components/graph2D/chartOptions.ts
@@ -310,7 +310,7 @@ function createSeries(yData: number[][], config: ChartConfig): EChartsOption['se
       smooth: config.smooth,
       showSymbol: config.showSymbol,
       itemStyle: { color: COLORS.LINES[i % COLORS.LINES.length] },
-      lineStyle: { color: COLORS.LINES[i % COLORS.LINES.length] },
+      lineStyle: { color: COLORS.LINES[i % COLORS.LINES.length], width: 3 },
       encode: {
         x: config.xAxis.name,
         y: i + 1,

--- a/frontend/src/hooks/usePlaybackData.ts
+++ b/frontend/src/hooks/usePlaybackData.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import type { RunResponse } from '@utils/api';
-import { buildGraphs } from '@utils/graph';
+import { buildCategorizedGraphs, type CategorizedGraphData } from '@utils/graph';
 import { ReplayController } from '@utils/ReplayController';
 import { timeAccessor } from '@types';
 
@@ -11,7 +11,7 @@ interface PlaybackLocationState {
 }
 
 interface UsePlaybackDataReturn {
-  graphs: ReturnType<typeof buildGraphs>;
+  categorizedGraphs: CategorizedGraphData[];
   replayController: ReplayController;
   times: number[];
 }
@@ -28,8 +28,8 @@ export const usePlaybackData = (): UsePlaybackDataReturn | null => {
     return simulationResult ? simulationResult.data.map(timeAccessor) : [];
   }, [simulationResult]);
 
-  const graphs = useMemo(() => {
-    return simulationResult ? buildGraphs(simulationResult) : [];
+  const categorizedGraphs = useMemo(() => {
+    return simulationResult ? buildCategorizedGraphs(simulationResult) : [];
   }, [simulationResult]);
 
   // Return null if simulation data is not available
@@ -38,7 +38,7 @@ export const usePlaybackData = (): UsePlaybackDataReturn | null => {
   }
 
   return {
-    graphs,
+    categorizedGraphs,
     replayController,
     times,
   };

--- a/frontend/src/pages/playback/Playback.module.scss
+++ b/frontend/src/pages/playback/Playback.module.scss
@@ -30,6 +30,31 @@
         grid-auto-rows: 1fr;
         overflow-x: hidden;
         padding-right: 1rem;
+
+        .sceneContainer {
+            grid-column: 1 / -1;
+            height: 60vh;
+            min-height: 500px;
+        }
+
+        .graphCategory {
+            grid-column: 1 / -1;
+            display: contents;
+
+            .categoryTitle {
+                grid-column: 1 / -1;
+                @include fonts.title-medium;
+                color: var(--primary);
+                margin: 2rem 0 0.5rem 1rem;
+                padding: 1rem;
+                border-bottom: 0.25rem solid white;
+            }
+
+            .categoryGraphs {
+                grid-column: 1 / -1;
+                display: contents;
+            }
+        }
     }
 
     .playbarContainer {

--- a/frontend/src/pages/playback/Playback.module.scss
+++ b/frontend/src/pages/playback/Playback.module.scss
@@ -34,7 +34,7 @@
         .sceneContainer {
             grid-column: 1 / -1;
             height: 60vh;
-            min-height: 500px;
+            min-height: 31.25rem;
         }
 
         .graphCategory {

--- a/frontend/src/pages/playback/Playback.tsx
+++ b/frontend/src/pages/playback/Playback.tsx
@@ -47,7 +47,7 @@ export const Playback = () => {
         return null;
     }
 
-    const { graphs, replayController, times } = playbackData;
+    const { categorizedGraphs, replayController, times } = playbackData;
 
     return (
         <div className={styles.playback}>
@@ -67,13 +67,22 @@ export const Playback = () => {
             </div>
 
             <div className={styles.displayGrid}>
-                <Scene3DViewer replayController={replayController} />
-                {graphs.map((graph, index) => (
-                    <Graph2D
-                        key={index}
-                        {...graph}
-                        replayController={replayController}
-                    />
+                <div className={styles.sceneContainer}>
+                    <Scene3DViewer replayController={replayController} />
+                </div>
+                {categorizedGraphs.map((category, categoryIndex) => (
+                    <div key={categoryIndex} className={styles.graphCategory}>
+                        <h2 className={styles.categoryTitle}>{category.title}</h2>
+                        <div className={styles.categoryGraphs}>
+                            {category.graphs.map((graph, graphIndex) => (
+                                <Graph2D
+                                    key={graphIndex}
+                                    {...graph}
+                                    replayController={replayController}
+                                />
+                            ))}
+                        </div>
+                    </div>
                 ))}
             </div>
             <div className={styles.playbarContainer}>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -113,6 +113,10 @@ export interface components {
     schemas: {
         /** CarForceBreakdownModel */
         CarForceBreakdownModel: {
+            /** Coupling Torque At Wheel */
+            coupling_torque_at_wheel: number;
+            /** Load Torque At Wheel */
+            load_torque_at_wheel: number;
             external_forces: components["schemas"]["ExternalLoadForceBreakdownModel"];
             /** Acceleration */
             acceleration: number;
@@ -305,6 +309,8 @@ export interface components {
         EngineForceBreakdownModel: {
             /** Torque */
             torque: number;
+            /** Coupling Torque At Engine */
+            coupling_torque_at_engine: number;
             /** Power */
             power: number;
             /** Angular Velocity */

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -23,6 +23,12 @@ const positionAccessor: AccessorStrategy = (point) => point.state.car_position;
 const velocityAccessor: AccessorStrategy = (point) => point.state.car_velocity;
 const accelerationAccessor: AccessorStrategy = (point) => point.system.car.acceleration;
 
+// Temp
+const couplingTorqueAtWheels: AccessorStrategy = (point) => point.system.car.coupling_torque_at_wheel;
+const loadTorqueAtWheels: AccessorStrategy = (point) => point.system.car.load_torque_at_wheel;
+
+const couplingTorqueAtEngine: AccessorStrategy = (point) => point.system.engine.coupling_torque_at_engine;
+
 // Engine and CVT stuff
 const cvtRatioAccessor: AccessorStrategy = (point) => point.system.cvt.cvt_ratio;
 const engineRpmAccessor: AccessorStrategy = (point) => point.system.engine.angular_velocity;
@@ -149,6 +155,9 @@ export const accessorToUnit = new Map<AccessorStrategy, BaseUnitType>([
     [secondaryRadialFromCentrifugalAccessor, 'force'],
     [secondaryRadialFromClampingAccessor, 'force'],
     [isSlippingAccessor, 'dimensionless'],
+    [couplingTorqueAtWheels, 'torque'],
+    [loadTorqueAtWheels, 'torque'],
+    [couplingTorqueAtEngine, 'torque'],
 ]);
 
 // Helper function to get unit label for an accessor
@@ -199,6 +208,36 @@ export const graphCategories: GraphCategory[] = [
         }
     },
 ]},
+{
+    title: "Acceleration of Engine and Car",
+    graphs: [
+        // Graphs for looking at accelration of engine and wheels as separate systems
+        {
+            xAccessor: timeAccessor,
+            yAccessor: [couplingTorqueAtWheels, loadTorqueAtWheels],
+            config: {
+                title: "Torques at Wheels vs Time",
+                xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
+                yAxis: { name: "Torque", type: "value", unit: getAxisUnit(couplingTorqueAtWheels) },
+                seriesNames: ["Coupling Torque at Wheels", "Load Torque at Wheels"],
+                showXLine: true,
+                showYLine: false
+            }
+        },
+        {
+            xAccessor: timeAccessor,
+            yAccessor: [couplingTorqueAtEngine, engineTorqueAccessor],
+            config: {
+                title: "Torques at Engine vs Time",
+                xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
+                yAxis: { name: "Torque", type: "value", unit: getAxisUnit(couplingTorqueAtEngine) },
+                seriesNames: ["Coupling Torque at Engine", "Engine Torque"],
+                showXLine: true,
+                showYLine: false
+            }
+        }
+    ]
+},
 {
     title: "External Load",
     graphs: [

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -13,6 +13,11 @@ type GraphConfig = {
     config: ChartConfig;
 };
 
+export type GraphCategory = {
+    title: string;
+    graphs: GraphConfig[];
+};
+
 export const timeAccessor: AccessorStrategy = (point) => point.time;
 const positionAccessor: AccessorStrategy = (point) => point.state.car_position;
 const velocityAccessor: AccessorStrategy = (point) => point.state.car_velocity;
@@ -156,8 +161,10 @@ function getAxisUnit(accessor: AccessorStrategy): string {
     return unit || '';
 }
 
-export const graphConfigs: GraphConfig[] = [
-    /** KINEMATICS GRAPHS */
+export const graphCategories: GraphCategory[] = [
+    {
+        title: "Kinematics",
+        graphs: [
     {
         xAccessor: timeAccessor,
         yAccessor: [positionAccessor],
@@ -191,6 +198,10 @@ export const graphConfigs: GraphConfig[] = [
             showYLine: false
         }
     },
+]},
+{
+    title: "External Load",
+    graphs: [
     /** EXTERNAL LOAD */
     {
         xAccessor: velocityAccessor,
@@ -204,6 +215,10 @@ export const graphConfigs: GraphConfig[] = [
             showYLine: false
         }
     },
+]},
+{
+    title: "CVT Ratio",
+    graphs: [
     /** CVT RATIO GRAPHS */
     {
         xAccessor: timeAccessor,
@@ -238,6 +253,10 @@ export const graphConfigs: GraphConfig[] = [
             showYLine: false
         }
     },
+]},
+{
+    title: "Engine",
+    graphs: [
     /** ENGINE GRAPHS */
     {
         xAccessor: timeAccessor,
@@ -272,6 +291,10 @@ export const graphConfigs: GraphConfig[] = [
             showYLine: false
         }
     },
+]},
+{
+    title: "Pulley Forces (Overall)",
+    graphs: [
     /** PRIM AND SEC OVERALL GRAPHS */
     { // Shows overall direction of shift
         xAccessor: timeAccessor,
@@ -297,6 +320,10 @@ export const graphConfigs: GraphConfig[] = [
             showYLine: false
         }
     },
+]},
+{
+    title: "Primary Pulley",
+    graphs: [
     /** PRIMARY GRAPHS */
     { // Primary axial force breakdown into components
         xAccessor: timeAccessor,
@@ -322,6 +349,10 @@ export const graphConfigs: GraphConfig[] = [
             showYLine: true
         }
     },
+]},
+{
+    title: "Secondary Pulley",
+    graphs: [
     /** SECONDARY GRAPHS */
     { // Top level breakdown of axial from helix and axial from spring
         xAccessor: timeAccessor,
@@ -371,6 +402,10 @@ export const graphConfigs: GraphConfig[] = [
             showYLine: false
         }
     },
+]},
+{
+    title: "Slip Model",
+    graphs: [
     /** SLIP MODEL GRAPHS */
     { // Slip model torques vs time
         xAccessor: timeAccessor,
@@ -407,4 +442,8 @@ export const graphConfigs: GraphConfig[] = [
             showYLine: false
         }
     }
+]}
 ];
+
+// Flatten categories into single array for backward compatibility
+export const graphConfigs: GraphConfig[] = graphCategories.flatMap(category => category.graphs);

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -17,27 +17,39 @@ export const timeAccessor: AccessorStrategy = (point) => point.time;
 const positionAccessor: AccessorStrategy = (point) => point.state.car_position;
 const velocityAccessor: AccessorStrategy = (point) => point.state.car_velocity;
 const accelerationAccessor: AccessorStrategy = (point) => point.system.car.acceleration;
+
+// Engine and CVT stuff
 const cvtRatioAccessor: AccessorStrategy = (point) => point.system.cvt.cvt_ratio;
 const engineRpmAccessor: AccessorStrategy = (point) => point.system.engine.angular_velocity;
 const engineTorqueAccessor: AccessorStrategy = (point) => point.system.engine.torque;
 const cvtRatioRateOfChangeAccessor: AccessorStrategy = (point) => point.system.slip.cvt_ratio_derivative;
 const enginePowerAccessor: AccessorStrategy = (point) => point.system.engine.power;
+
+// Slip model accessors
 const t_max_primAccessor: AccessorStrategy = (point) => point.system.slip.t_max_prim;
 const t_max_secAccessor: AccessorStrategy = (point) => point.system.slip.t_max_sec;
 const coupling_torqueAccessor: AccessorStrategy = (point) => point.system.slip.coupling_torque;
 const torque_demandAccessor: AccessorStrategy = (point) => point.system.slip.torque_demand;
-const primaryRadialForceAccessor: AccessorStrategy = (point) => point.system.cvt.primaryPulleyState.forces.radial_force;
-const primaryClampingForceAccessor: AccessorStrategy = (point) => point.system.cvt.primaryPulleyState.forces.clamping_force;
-const secondaryRadialForceAccessor: AccessorStrategy = (point) => point.system.cvt.secondaryPulleyState.forces.radial_force;
-const secondaryClampingForceAccessor: AccessorStrategy = (point) => point.system.cvt.secondaryPulleyState.forces.clamping_force;
+const isSlippingAccessor: AccessorStrategy = (point) => point.system.slip.is_slipping ? 1 : 0;
+
+// External load
 const inclineForceAccessor: AccessorStrategy = (point) => point.system.car.external_forces.incline_force;
 const dragForceAccessor: AccessorStrategy = (point) => point.system.car.external_forces.drag_force;
 const totalExternalLoadAccessor: AccessorStrategy = (point) => point.system.car.external_forces.net;
-const primaryCentrifugalForceAccessor: AccessorStrategy = (point) => point.system.cvt.primaryPulleyState.radial_from_centrifugal;
+
+// Overall pulley radial force (combined)
+const primaryRadialForceAccessor: AccessorStrategy = (point) => point.system.cvt.primaryPulleyState.forces.radial_force;
+const secondaryRadialForceAccessor: AccessorStrategy = (point) => point.system.cvt.secondaryPulleyState.forces.radial_force;
+
+// Components of radial force prior to 2sin(phi/2) multiplication
+const primaryRadialFromCentrifugalAccessor: AccessorStrategy = (point) => point.system.cvt.primaryPulleyState.radial_from_centrifugal;
 const primaryRadialFromClampingAccessor: AccessorStrategy = (point) => point.system.cvt.primaryPulleyState.radial_from_clamping;
-const secondaryCentrifugalForceAccessor: AccessorStrategy = (point) => point.system.cvt.secondaryPulleyState.radial_from_centrifugal;
+const secondaryRadialFromCentrifugalAccessor: AccessorStrategy = (point) => point.system.cvt.secondaryPulleyState.radial_from_centrifugal;
 const secondaryRadialFromClampingAccessor: AccessorStrategy = (point) => point.system.cvt.secondaryPulleyState.radial_from_clamping;
-const isSlippingAccessor: AccessorStrategy = (point) => point.system.slip.is_slipping ? 1 : 0;
+
+// Overall pulley clamping force (Axial)
+const primaryClampingForceAccessor: AccessorStrategy = (point) => point.system.cvt.primaryPulleyState.forces.clamping_force;
+const secondaryClampingForceAccessor: AccessorStrategy = (point) => point.system.cvt.secondaryPulleyState.forces.clamping_force;
 
 // Helper function to extract values from breakdown with proper error handling
 function getBreakdownValue<T>(
@@ -66,6 +78,11 @@ function getBreakdownValue<T>(
 const primaryFlyweightForceAccessor: AccessorStrategy = (point) => {
     const prf = point.system.cvt.primaryPulleyState.breakdown;
     return getBreakdownValue(prf, ['flyweightForce', 'net'], "primary pulley");
+};
+
+const rawFlyweightCentrifugalForce: AccessorStrategy = (point) => {
+    const prf = point.system.cvt.primaryPulleyState.breakdown;
+    return getBreakdownValue(prf, ['flyweightForce', 'centrifugal_force'], "primary pulley");
 };
 
 const primarySpringForceAccessor: AccessorStrategy = (point) => {
@@ -111,6 +128,7 @@ export const accessorToUnit = new Map<AccessorStrategy, BaseUnitType>([
     [primaryRadialForceAccessor, 'force'],
     [secondaryRadialForceAccessor, 'force'],
     [primaryFlyweightForceAccessor, 'force'],
+    [rawFlyweightCentrifugalForce, 'force'],
     [primarySpringForceAccessor, 'force'],
     [secondaryHelixFeedbackTorqueAccessor, 'torque'],
     [secondaryHelixSpringTorqueAccessor, 'torque'],
@@ -121,9 +139,9 @@ export const accessorToUnit = new Map<AccessorStrategy, BaseUnitType>([
     [inclineForceAccessor, 'force'],
     [dragForceAccessor, 'force'],
     [totalExternalLoadAccessor, 'force'],
-    [primaryCentrifugalForceAccessor, 'force'],
+    [primaryRadialFromCentrifugalAccessor, 'force'],
     [primaryRadialFromClampingAccessor, 'force'],
-    [secondaryCentrifugalForceAccessor, 'force'],
+    [secondaryRadialFromCentrifugalAccessor, 'force'],
     [secondaryRadialFromClampingAccessor, 'force'],
     [isSlippingAccessor, 'dimensionless'],
 ]);
@@ -139,6 +157,7 @@ function getAxisUnit(accessor: AccessorStrategy): string {
 }
 
 export const graphConfigs: GraphConfig[] = [
+    /** KINEMATICS GRAPHS */
     {
         xAccessor: timeAccessor,
         yAccessor: [positionAccessor],
@@ -172,6 +191,20 @@ export const graphConfigs: GraphConfig[] = [
             showYLine: false
         }
     },
+    /** EXTERNAL LOAD */
+    {
+        xAccessor: velocityAccessor,
+        yAccessor: [totalExternalLoadAccessor, inclineForceAccessor, dragForceAccessor],
+        config: {
+            title: "External Load Forces vs Vehicle Speed",
+            xAxis: { name: "Vehicle Speed", type: "value", unit: getAxisUnit(velocityAccessor) },
+            yAxis: { name: "Force", type: "value", unit: getAxisUnit(inclineForceAccessor) },
+            seriesNames: ["Total External Load", "Incline Force", "Air Resistance"],
+            showXLine: true,
+            showYLine: false
+        }
+    },
+    /** CVT RATIO GRAPHS */
     {
         xAccessor: timeAccessor,
         yAccessor: [cvtRatioAccessor],
@@ -179,6 +212,17 @@ export const graphConfigs: GraphConfig[] = [
             title: "CVT Ratio vs Time",
             xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
             yAxis: { name: "CVT Ratio", type: "value", unit: getAxisUnit(cvtRatioAccessor) },
+            showXLine: true,
+            showYLine: false
+        }
+    },
+    {
+        xAccessor: timeAccessor,
+        yAccessor: [cvtRatioRateOfChangeAccessor],
+        config: {
+            title: "CVT Ratio Rate of Change vs Time",
+            xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
+            yAxis: { name: "CVT Ratio Rate of Change", type: "value", unit: getAxisUnit(cvtRatioRateOfChangeAccessor) },
             showXLine: true,
             showYLine: false
         }
@@ -194,7 +238,7 @@ export const graphConfigs: GraphConfig[] = [
             showYLine: false
         }
     },
-    // Just engine rpm vs time
+    /** ENGINE GRAPHS */
     {
         xAccessor: timeAccessor,
         yAccessor: [engineRpmAccessor],
@@ -202,7 +246,6 @@ export const graphConfigs: GraphConfig[] = [
             title: "Engine RPM vs Time",
             xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
             yAxis: { name: "Engine RPM", type: "value", unit: getAxisUnit(engineRpmAccessor) },
-            height: 400,
             showXLine: true,
             showYLine: false
         }
@@ -229,139 +272,137 @@ export const graphConfigs: GraphConfig[] = [
             showYLine: false
         }
     },
-    {
+    /** PRIM AND SEC OVERALL GRAPHS */
+    { // Shows overall direction of shift
         xAccessor: timeAccessor,
         yAccessor: [primaryRadialForceAccessor, secondaryRadialForceAccessor],
         config: {
-            title: "Pulley Radial Forces vs Time",
+            title: "Pulley Net Radial Forces vs Time",
             xAxis: { name: "Time", type: "value", unit: "s" },
             yAxis: { name: "Radial Force", type: "value", unit: "N" },
-            seriesNames: ["Primary ", "Secondary"],
+            seriesNames: ["Primary Net", "Secondary Net"],
             showXLine: true,
             showYLine: false
         }
     },
-    {
+    { // Breakdown of radial force in belt centrifugal and clamping
         xAccessor: timeAccessor,
-        yAccessor: [primaryCentrifugalForceAccessor, primaryRadialFromClampingAccessor, secondaryCentrifugalForceAccessor, secondaryRadialFromClampingAccessor],
+        yAccessor: [ primaryRadialFromClampingAccessor, secondaryRadialFromClampingAccessor, primaryRadialFromCentrifugalAccessor, secondaryRadialFromCentrifugalAccessor],
         config: {
-            title: "Pulley Force Components vs Time",
+            title: "Radial Breakdown vs Time",
             xAxis: { name: "Time", type: "value", unit: "s" },
             yAxis: { name: "Force", type: "value", unit: "N" },
-            seriesNames: ["Primary Centrifugal", "Primary Pulley", "Secondary Centrifugal", "Secondary Pulley"],
-            height: 400,
+            seriesNames: ["Primary Pulley", "Secondary Pulley", "Primary Centrifugal", "Secondary Centrifugal"],
             showXLine: true,
             showYLine: false
         }
     },
-    {
-        xAccessor: timeAccessor,
-        yAccessor: [cvtRatioRateOfChangeAccessor],
-        config: {
-            title: "CVT Ratio Rate of Change vs Time",
-            xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
-            yAxis: { name: "CVT Ratio Rate of Change", type: "value", unit: getAxisUnit(cvtRatioRateOfChangeAccessor) },
-            showXLine: true,
-            showYLine: false
-        }
-    },
-    {
+    /** PRIMARY GRAPHS */
+    { // Primary axial force breakdown into components
         xAccessor: timeAccessor,
         yAccessor: [primaryClampingForceAccessor, primaryFlyweightForceAccessor, primarySpringForceAccessor],
         config: {
-            title: "Primary Forces vs Time",
+            title: "Primary Axial Forces vs Time",
             xAxis: { name: "Time", type: "value", unit: "s" },
-            yAxis: { name: "Primary Force", type: "value", unit: "N" },
+            yAxis: { name: "Force", type: "value", unit: "N" },
             seriesNames: ["Net", "Flyweight", "Spring"],
             showXLine: true,
             showYLine: false
         }
     },
-    {
-        xAccessor: timeAccessor,
-        yAccessor: [primaryRadialForceAccessor, primaryFlyweightForceAccessor, primarySpringForceAccessor],
+    { // Visualize how much ramp is doing(raw vs post ramp)
+        xAccessor: engineRpmAccessor,
+        yAccessor: [rawFlyweightCentrifugalForce, primaryFlyweightForceAccessor],
         config: {
-            title: "Primary Forces vs Time",
-            xAxis: { name: "Time", type: "value", unit: "s" },
-            yAxis: { name: "Primary Force", type: "value", unit: "N" },
-            seriesNames: ["Net", "Flyweight", "Spring"],
+            title: "Ramp Impact (Raw vs Post-Ramp) vs Engine RPM",
+            xAxis: { name: "Engine RPM", type: "value", unit: getAxisUnit(engineRpmAccessor) },
+            yAxis: { name: "Force", type: "value", unit: "N" },
+            seriesNames: ["Raw Flyweight", "Flyweight"],
             showXLine: true,
-            showYLine: false
+            showYLine: true
         }
     },
-    {
+    /** SECONDARY GRAPHS */
+    { // Top level breakdown of axial from helix and axial from spring
         xAccessor: timeAccessor,
         yAccessor: [secondaryClampingForceAccessor, secondaryHelixForceAccessor, secondarySpringCompForceAccessor],
         config: {
-            title: "Secondary Forces vs Time",
+            title: "Secondary Axial Forces vs Time",
             xAxis: { name: "Time", type: "value", unit: "s" },
             yAxis: { name: "Secondary Force", type: "value", unit: "N" },
             seriesNames: ["Net", "Helix Force", "Spring Comp Force"],
-            height: 400,
             showXLine: true,
             showYLine: false
         }
     },
-    {
+    { // Torques that go into the helix
         xAccessor: timeAccessor,
         yAccessor: [secondaryHelixFeedbackTorqueAccessor, secondaryHelixSpringTorqueAccessor],
         config: {
-            title: "Secondary Helix Torques vs Time",
+            title: "Secondary Torques vs Time",
             xAxis: { name: "Time", type: "value", unit: "s" },
             yAxis: { name: "Torque", type: "value", unit: "N·m" },
-            seriesNames: ["Helix Feedback Torque", "Helix Spring Torque"],
-            height: 400,
+            seriesNames: ["Reactive Feedback", "Torsional Spring"],
             showXLine: true,
             showYLine: false
         }
     },
-    {
+    { // Same graph as 2 above, but vs CVT ratio
+        xAccessor: cvtRatioAccessor,
+        yAccessor: [secondaryClampingForceAccessor, secondaryHelixForceAccessor, secondarySpringCompForceAccessor],
+        config: {
+            title: "Secondary Axial Forces vs CVT RATIO",
+            xAxis: { name: "CVT RATIO", type: "value", unit: getAxisUnit(cvtRatioAccessor) },
+            yAxis: { name: "Secondary Force", type: "value", unit: "N" },
+            seriesNames: ["Net", "Helix Force", "Spring Comp Force"],
+            showXLine: true,
+            showYLine: false
+        }
+    },
+    { // Same graph as 2 above, but vs CVT ratio
+        xAccessor: cvtRatioAccessor,
+        yAccessor: [secondaryHelixFeedbackTorqueAccessor, secondaryHelixSpringTorqueAccessor],
+        config: {
+            title: "Secondary Torques vs CVT RATIO",
+            xAxis: { name: "CVT RATIO", type: "value", unit: getAxisUnit(cvtRatioAccessor) },
+            yAxis: { name: "Torque", type: "value", unit: "N·m" },
+            seriesNames: ["Reactive Feedback", "Torsional Spring"],
+            showXLine: true,
+            showYLine: false
+        }
+    },
+    /** SLIP MODEL GRAPHS */
+    { // Slip model torques vs time
         xAccessor: timeAccessor,
         yAccessor: [coupling_torqueAccessor, torque_demandAccessor, t_max_primAccessor, t_max_secAccessor],
         config: {
             title: "Slip Model Torques vs Time",
             xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
             yAxis: { name: "Torque", type: "value", unit: getAxisUnit(coupling_torqueAccessor) },
-            seriesNames: ["Coupling Torque", "Torque Demand", "T_max (Primary)", "T_max (Secondary)"],
-            height: 400,
+            seriesNames: ["Coupling", "Demand", "T_max (Primary)", "T_max (Secondary)"],
             showXLine: true,
             showYLine: false
         }
     },
-        {
+    { // Same graph but vs Engine RPM (is this useful?)
         xAccessor: engineRpmAccessor,
         yAccessor: [coupling_torqueAccessor, t_max_primAccessor, t_max_secAccessor],
         config: {
             title: "Slip Model Torques vs Engine RPM",
             xAxis: { name: "Engine RPM", type: "value", unit: getAxisUnit(engineRpmAccessor) },
             yAxis: { name: "Torque", type: "value", unit: "N·m" },
-            seriesNames: ["Coupling Torque", "T_max (Primary)", "T_max (Secondary)"],
-            height: 400,
+            seriesNames: ["Coupling", "T_max (Primary)", "T_max (Secondary)"],
             showXLine: true,
             showYLine: false
         }
     },
-    {
-        xAccessor: velocityAccessor,
-        yAccessor: [totalExternalLoadAccessor, inclineForceAccessor, dragForceAccessor],
-        config: {
-            title: "External Load Forces vs Vehicle Speed",
-            xAxis: { name: "Vehicle Speed", type: "value", unit: getAxisUnit(velocityAccessor) },
-            yAxis: { name: "Force", type: "value", unit: getAxisUnit(inclineForceAccessor) },
-            seriesNames: ["Total External Load", "Incline Force", "Air Resistance"],
-            height: 400,
-            showXLine: true,
-            showYLine: false
-        }
-    },
-    {
+    { // Whether you are slipping or not vs time
         xAccessor: timeAccessor,
         yAccessor: [isSlippingAccessor],
         config: {
             title: "Is Slipping vs Time",
             xAxis: { name: "Time", type: "value", unit: getAxisUnit(timeAccessor) },
             yAxis: { name: "Is Slipping", type: "value", unit: "dimensionless" },
-            height: 400,
             showXLine: true,
             showYLine: false
         }

--- a/frontend/src/utils/conversion/timeStepDataConversion.ts
+++ b/frontend/src/utils/conversion/timeStepDataConversion.ts
@@ -39,11 +39,14 @@ function convertTimeStepData(
     },
     engine: {
       torque: conv(timeStep.system.engine.torque, 'torque'),
+      coupling_torque_at_engine: conv(timeStep.system.engine.coupling_torque_at_engine, 'torque'),
       power: conv(timeStep.system.engine.power, 'power'),
       angular_velocity: conv(timeStep.system.engine.angular_velocity, 'angular_velocity'),
       angular_acceleration: conv(timeStep.system.engine.angular_acceleration, 'angular_acceleration')
     },
     car: {
+      coupling_torque_at_wheel: conv(timeStep.system.car.coupling_torque_at_wheel, 'torque'),
+      load_torque_at_wheel: conv(timeStep.system.car.load_torque_at_wheel, 'torque'),
       external_forces: {
         incline_force: conv(timeStep.system.car.external_forces.incline_force, 'force'),
         drag_force: conv(timeStep.system.car.external_forces.drag_force, 'force'),

--- a/frontend/src/utils/graph.ts
+++ b/frontend/src/utils/graph.ts
@@ -1,32 +1,45 @@
 import type { Graph2DProps } from "@components/graph2D/graph2D";
 import type { RunResponse } from "./api";
-import { graphConfigs } from "@types";
+import { graphCategories } from "@types";
 
 // Graph data without runtime dependencies like replayController
 export type GraphData = Omit<Graph2DProps, 'replayController'>;
 
+export type CategorizedGraphData = {
+    title: string;
+    graphs: GraphData[];
+};
+
 // Cache for built graphs to maintain referential stability
-let cachedGraphs: GraphData[] | null = null;
+let cachedCategorizedGraphs: CategorizedGraphData[] | null = null;
 let cachedData: RunResponse['data'] | null = null;
 
-export function buildGraphs(run: RunResponse): GraphData[] {
+export function buildCategorizedGraphs(run: RunResponse): CategorizedGraphData[] {
     const data = run.data;
 
     // Return cached graphs if data hasn't changed (referential equality)
-    if (cachedGraphs && cachedData === data) {
-        return cachedGraphs;
+    if (cachedCategorizedGraphs && cachedData === data) {
+        return cachedCategorizedGraphs;
     }
 
-    // Build new graphs
-    const graphs = graphConfigs.map((config) => ({
-        xData: data.map(config.xAccessor),
-        yData: data.map((point) => config.yAccessor.map((accessor) => accessor(point))),
-        ...config,
+    // Build categorized graphs
+    const categorizedGraphs = graphCategories.map((category) => ({
+        title: category.title,
+        graphs: category.graphs.map((config) => ({
+            xData: data.map(config.xAccessor),
+            yData: data.map((point) => config.yAccessor.map((accessor) => accessor(point))),
+            ...config,
+        })),
     }));
 
     // Update cache
     cachedData = data;
-    cachedGraphs = graphs;
+    cachedCategorizedGraphs = categorizedGraphs;
 
-    return graphs;
+    return categorizedGraphs;
+}
+
+// Flatten for backward compatibility
+export function buildGraphs(run: RunResponse): GraphData[] {
+    return buildCategorizedGraphs(run).flatMap(category => category.graphs);
 }


### PR DESCRIPTION
**Description**
Update the visuals, separation and which graphs are shown to more easily view the results in an understandable way

**Changes**
List the main changes made in this PR:
- [X] Fixed bug for caching tooltip
- [X] Updated which graphs are shown and in which order
- [X] Added categories to graphs
- [X] Tweaked graph styling

**Screenshots (if applicable)**
<img width="2550" height="1302" alt="image" src="https://github.com/user-attachments/assets/4f3ff630-f9d2-4262-a683-013bf0d09aa3" />

**Additional Notes**
This isn't meant to look gorgeous, it's meant to be more functional and organized than before