### PR TITLE
Index Line Zoom

### DIFF
--- a/frontend/src/components/graph2D/indexOverlay/IndexOverlay.tsx
+++ b/frontend/src/components/graph2D/indexOverlay/IndexOverlay.tsx
@@ -296,8 +296,18 @@ export function IndexOverlay({
         return;
       }
 
-      // Position index line
+      // Position index line — hide if the current x value is outside the zoomed viewport
       const px = chart.convertToPixel({ xAxisIndex: 0 }, xValue) as number;
+      const inBounds = px >= rect.x && px <= rect.x + rect.width;
+
+      if (!inBounds) {
+        lineEl.style.display = 'none';
+        dotEls.forEach((dotEl) => {
+          if (dotEl) dotEl.style.display = 'none';
+        });
+        return;
+      }
+
       lineEl.style.transform = `translate3d(${px}px, ${rect.y}px, 0)`;
       lineEl.style.height = `${rect.height}px`;
       lineEl.style.display = 'block';

--- a/frontend/src/components/graph2D/indexOverlay/IndexOverlay.tsx
+++ b/frontend/src/components/graph2D/indexOverlay/IndexOverlay.tsx
@@ -296,28 +296,30 @@ export function IndexOverlay({
         return;
       }
 
-      // Position index line — hide if the current x value is outside the zoomed viewport
+      // Position index line — hide if the current x or y value is outside the zoomed viewport
       const px = chart.convertToPixel({ xAxisIndex: 0 }, xValue) as number;
-      const inBounds = px >= rect.x && px <= rect.x + rect.width;
+      const inBoundsX = px >= rect.x && px <= rect.x + rect.width;
 
-      if (!inBounds) {
+      if (!inBoundsX) {
         lineEl.style.display = 'none';
         dotEls.forEach((dotEl) => {
           if (dotEl) dotEl.style.display = 'none';
         });
         return;
       }
-
+      
       lineEl.style.transform = `translate3d(${px}px, ${rect.y}px, 0)`;
       lineEl.style.height = `${rect.height}px`;
       lineEl.style.display = 'block';
 
       // Position dots
-      yValues.forEach((yValue, seriesIndex) => {
-        const dotEl = dotEls[seriesIndex];
-        if (!dotEl) return;
-        if (yValue != null) {
-          const py = chart.convertToPixel({ yAxisIndex: 0 }, yValue) as number;
+      dotEls.forEach((dotEl, seriesIndex) => {
+        const yValue = yValues[seriesIndex];
+        if (!dotEl || yValue == null) return;
+
+        const py = chart.convertToPixel({ yAxisIndex: 0 }, yValue) as number;
+        const inBoundsY = py >= rect.y && py <= rect.y + rect.height;
+        if (inBoundsY) {
           dotEl.style.transform = `translate3d(${px - 6}px, ${py - 6}px, 0)`;
           dotEl.style.display = 'block';
         } else {
@@ -325,9 +327,10 @@ export function IndexOverlay({
         }
       });
 
-      for (let i = yValues.length; i < dotEls.length; i++) {
-        if (dotEls[i]) dotEls[i].style.display = 'none';
-      }
+      // Not sure what this code does
+      // for (let i = yValues.length; i < dotEls.length; i++) {
+      //   if (dotEls[i]) dotEls[i].style.display = 'none';
+      // }
 
       // Build tooltip HTML
       const xLabel = xAxis.unit

--- a/frontend/src/utils/ReplayController.ts
+++ b/frontend/src/utils/ReplayController.ts
@@ -161,7 +161,7 @@ export class ReplayController {
     if (latest) {
       this.emit({
         type: ReplayEventType.Progress,
-        currentIndex: this.currentIndex,
+        currentIndex: this.currentIndex - 1,
         data: latest, // only the newest point this frame
       });
     }


### PR DESCRIPTION
**Description**
Fixed bug where index lines where being displayed outside chart bounds when after zooming

**Changes**
List the main changes made in this PR:
- [x] Hide index line when outside chart bounds
- [x] Fix index to not go outside limits

**Screenshots (if applicable)**
Add screenshots to show the changes (if any).

**Additional Notes**
Any other things of note, could include bugs, new warnings, or other things changed that do not concern the main PR content.